### PR TITLE
Add prop-types package, add prop types to city selector component

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "gh-pages": "^2.0.1",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21",
+    "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-load-script": "0.0.6",

--- a/src/Components/CitySelector/cityselector.js
+++ b/src/Components/CitySelector/cityselector.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Script from 'react-load-script'
+import PropTypes from 'prop-types'
 
 import Styles from './cityselector.module.css'
 
@@ -22,4 +23,14 @@ const CitySelector = (props) => {
         </div>
     )
 }
+
+CitySelector.propTypes = {
+    apikey:PropTypes.string,
+    error:PropTypes.func,
+    loaded:PropTypes.func,
+    city:PropTypes.string,
+    changed:PropTypes.func,
+    clicked:PropTypes.func
+}
+
 export default CitySelector


### PR DESCRIPTION
I have installed the prop-types package, and also added the prop type checker inside city selector component. Merge if everything looks right, let's use this thread to complete the rest of the prop types.